### PR TITLE
Fix event handlers in IntroSC.astro

### DIFF
--- a/src/components/IntroSC.astro
+++ b/src/components/IntroSC.astro
@@ -51,21 +51,18 @@ new p5((p) => {
 
     p.stroke(0, 255, 0);
     p.noFill();
+  };
 
-    p.mousePressed = () => {
-      p.redraw();
-    };
+  p.mousePressed = () => {
+    p.redraw();
+  };
 
-    p.windowResized = () => {
+  p.windowResized = () => {
     const container = document.getElementById('sketch-container');
     const width = container?.offsetWidth;
     const height = container?.offsetHeight;
     p.resizeCanvas(width, height);
     p.redraw();
-  };
-
-
-
   };
 });
 


### PR DESCRIPTION
## Summary
- avoid re-registering p5 event handlers on every frame in `IntroSC.astro`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840a7dcd10c83308e477c9d507787d3